### PR TITLE
Added possibility to exclude directory(-ies) from scan

### DIFF
--- a/Docs/Controllers/DocsController.php
+++ b/Docs/Controllers/DocsController.php
@@ -2,6 +2,7 @@
 
 namespace Igsem\Docs\Controllers;
 
+use Igsem\Docs\Services\DocsService;
 use Phalcon\Mvc\Controller;
 use Phalcon\Mvc\View\Simple;
 
@@ -21,7 +22,8 @@ class DocsController extends Controller
     {
         /** @var array $config */
         $config = $this->di->get('swagger');
-        $swagger = \Swagger\scan($config['path']);
+        $options = DocsService::getOptions($config);
+        $swagger = \Swagger\scan($config['path'], $options);
         $swagger->host = $config['host'];
         $swagger->schemes = $config['schemes'];
         $swagger->basePath = $config['basePath'];

--- a/Docs/Services/DocsService.php
+++ b/Docs/Services/DocsService.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Igsem\Docs\Services;
+
+use Phalcon\Config;
+use Phalcon\Di\Service;
+
+class DocsService extends Service
+{
+    /**
+     * Get options for scan
+     *
+     * @param array $config
+     * @return array
+     */
+    public static function getOptions(array $config)
+    {
+        $options = [];
+        if (array_key_exists('exclude', $config)) {
+            $options['exclude'] = self::getExclude($config['exclude']);
+        }
+        return $options;
+    }
+
+    /**
+     * Get exclude options property
+     *
+     * @param mixed $exclude
+     * @return string|array|null
+     */
+    protected static function getExclude($exclude)
+    {
+        if (is_string($exclude)) {
+            return $exclude;
+        }
+        if ($exclude instanceof Config) {
+            return $exclude->toArray();
+        }
+        return null;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Here I am loading the configuration from an .env file:
         'description' => getenv('SWAGGER_DESCRIPTION'),
         'email' => getenv('SWAGGER_EMAIL'),
         'jsonUri' => getenv('SWAGGER_JSON_URI'),
+        'exclude' => explode(',', getenv('SWAGGER_EXCLUDE')),
     ],
 ```
 
@@ -90,6 +91,9 @@ These values are expected and mandatory:
 - description  - description of your application
 - email - contact email
 - jsonUri - the url you configured for the json response e.g. /swagger-json
+
+These values are optional:
+- exclude [string|array] - a path(s) to exclude from scanning, ex. ```APP_PATH. '/src/path_to_exclude/'``` or ```[APP_PATH. '/src/path_to_exclude_1/', APP_PATH. '/src/path_to_exclude_2/']```
 
 
 ### Usage 
@@ -128,7 +132,7 @@ I recommend to have an annotation on your base controller like this:
 class BaseController
 ```
 
-!Please note that the configuration si overwriting the annotation, therefore use this as an extend only!
+!Please note that the configuration is overwriting the annotation, therefore use this as an extend only!
 
 ![alt text](https://github.com/JuliusKoronci/phalcon-swagger/blob/master/screen.png "Screen of Swagger UI")
 


### PR DESCRIPTION
Swagger-php library has an option to exclude path(s) from scan, which is currently missing in this library, so I've added this possibility